### PR TITLE
fix(cart): prevent item reordering on refetch by sorting cartItems by id

### DIFF
--- a/src/app-core/Customers/Services/Carts/Get-Cart.js
+++ b/src/app-core/Customers/Services/Carts/Get-Cart.js
@@ -8,6 +8,8 @@ export async function getCartService(userId) {
   }
 
   const cartItems = await getCartItems(cart.id);
+  
+   cartItems.sort((a, b) => Number(a.id) - Number(b.id));
 
   const products = cartItems.map(item => ({
     id: item.id.toString(),


### PR DESCRIPTION
This PR improves the stability of the cart API response by enforcing a consistent ordering of cart items after refetch operations.
Previously, users experienced item reordering in their cart after updating quantities and triggering a refetch, which caused a confusing UX.

Now, cartItems are sorted by their numeric id before being returned from the getCartService, ensuring deterministic and predictable ordering across all requests.